### PR TITLE
第1回のCSSのコードハイライトを等幅フォントに変更

### DIFF
--- a/1st/original.css
+++ b/1st/original.css
@@ -61,6 +61,7 @@ body {
  *********************************************/
 .reveal p {
   margin: 20px 0;
+  text-align: left;
   line-height: 1.3; }
 
 /* Ensure certain elements are never larger than the slide itself */
@@ -133,7 +134,11 @@ body {
   box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.3); }
 
 .reveal code {
-  font-family: Ricty; }
+  display: inline;
+  word-wrap: normal;
+  background: #3F3F3F;
+  color: #DCDCDC;
+  font-family: "Courier New", Consolas, monospace; }
 
 .reveal pre code {
   display: block;


### PR DESCRIPTION
- スニペットではない、文中の<code></code>にも網掛けがかかるように変更
- 他の会への適用は追って実施